### PR TITLE
More reliable startup logic:

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -6,17 +6,15 @@ import traceback
 import os
 import asyncio
 from loguru import logger
-import websockets
 
 GATEWAY_ENDPOINT = os.environ.get("GATEWAY_ENDPOINT", "http://localhost:10000/api/1.0.0/translate")
 GATEWAY_READY = os.environ.get("GATEWAY_READY", "http://localhost:10000/")
 SEGMENTER_READY = os.environ.get("SEGMENTER_READY", "http://localhost:6000/segment")
 BACKEND_READY = os.environ.get("BACKEND_READY", "http://localhost:5000/translate/batch")
-MARIAN_READY = os.environ.get("MARIAN_READY", "ws://localhost:8050/translate")
 
 class NTEUAdapterTilde(QuartService):
 
-    async def wait_for_success(self, component, make_request):
+    async def wait_for_success(self, component, make_request, expected_response_code = 200):
         logger.info(f"Waiting for {component} to become ready")
         tries = 30
         while tries > 0:
@@ -25,49 +23,34 @@ class NTEUAdapterTilde(QuartService):
                 async with make_request(self.session) as client_response:
                     resp_text = await client_response.text()
                     resp_len = len(resp_text)
-                    if client_response.ok:
-                        logger.info(f"Request to {component} succeeded: {resp_len} characters in response")
-                        if resp_len < 100:
-                            logger.info(f"Response was: {resp_text}")
+                    logger.info(f"Request to {component} received response code {client_response.status}: {resp_len} characters in response")
+                    if resp_len < 100:
+                        logger.info(f"Response was: {resp_text}")
+                    if client_response.status == expected_response_code:
+                        logger.info(f"{component} is now 'successful'")
                         return
-                    else:
-                        logger.info(f"Request to {component} failed: {resp_len} characters in response")
             except Exception as ex:
                 logger.info(f"Request to {component} failed with an exception: {ex}")
             await asyncio.sleep(1)
         raise RuntimeError(f"{component} did not become ready")
-
-    async def wait_for_marian(self):
-        logger.info("Waiting for marian-server to become ready")
-        tries = 30
-        while tries > 0:
-            tries -= 1
-            try:
-                async with websockets.connect(MARIAN_READY) as websocket:
-                    await websocket.send("Test")
-                    resp_text = await websocket.recv()
-                    resp_len = len(resp_text)
-                    logger.info(f"Marian responded with {resp_len} characters")
-                    if resp_len < 100:
-                        logger.info(f"Response was: {resp_text}")
-                    return
-            except Exception as ex:
-                logger.info(f"Request to marian failed with an exception: {ex}")
-            await asyncio.sleep(1)
-        raise RuntimeError(f"marian did not become ready")
 
 
     async def setup(self):
         self.session = aiohttp.ClientSession()
         # Ensure all dependencies are up before we start listening
         try:
+            # First wait for the backend to be up and listening for requests at
+            # all - we check this by sending the wrong HTTP method to the
+            # endpoint and expecting a 405 method not allowed rather than a TCP
+            # connection failure
+            await self.wait_for_success("backend-up", lambda s: s.get(BACKEND_READY), 405)
+            # Give backend a few seconds to complete initialization
+            await asyncio.sleep(5)
             await asyncio.gather(
+                self.wait_for_success("backend-working", lambda s: s.post(BACKEND_READY, json={'texts':['test']})),
                 self.wait_for_success("gateway", lambda s: s.get(GATEWAY_READY)),
                 self.wait_for_success("segmenter", lambda s: s.post(SEGMENTER_READY, json={'texts':['test'],'lang':'en'})),
-                self.wait_for_marian()
             )
-            await asyncio.sleep(3)
-            await self.wait_for_success("backend", lambda s: s.post(BACKEND_READY, json={'texts':['test']}))
         except:
             os._exit(1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 elg[quart]
 aiohttp
-websockets


### PR DESCRIPTION
1. Wait for backend to start listening
2. Then pause a few seconds to let it complete startup
3. Then fire a test translation request and wait for that to succeed
4. Only then start listening for incoming requests.